### PR TITLE
Manage screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /config/jira-private.pem
 
 /public/assets/
+/public/system/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM ruby:2.3.3
-RUN apt-get update -qq && apt-get install -y build-essential libmysqlclient-dev nodejs
-RUN mkdir /pop
+
+RUN apt-get update -qq && apt-get install -y build-essential libmysqlclient-dev nodejs && mkdir /pop
 WORKDIR /pop
-ADD Gemfile /pop/Gemfile
-ADD Gemfile.lock /pop/Gemfile.lock
-RUN bundle install
+
+RUN echo deb http://archive.ubuntu.com/ubuntu precise main universe > /etc/apt/sources.list && \
+  echo deb http://archive.ubuntu.com/ubuntu precise-updates main universe >> /etc/apt/sources.list && \
+  apt-get update && \
+  apt-get install -y imagemagick && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 ADD . /pop
+RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'best_in_place'
 
 gem 'redcarpet'
 
+gem "paperclip", "~> 4.2"
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
       railties (>= 3.2)
     builder (3.2.3)
     chronic (0.10.2)
+    climate_control (0.2.0)
+    cocaine (0.5.8)
+      climate_control (>= 0.0.3, < 1.0)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -94,6 +97,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mimemagic (0.3.0)
     mini_backtrace (0.1.3)
       minitest (> 1.2.0)
       rails (>= 2.3.3)
@@ -127,6 +131,12 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    paperclip (4.3.7)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (= 0.3.0)
     rack (2.0.2)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -215,6 +225,7 @@ DEPENDENCIES
   minitest-reporters
   mysql2 (~> 0.3.18)
   omniauth-google-oauth2 (~> 0.1.19)
+  paperclip (~> 4.2)
   rails (= 5.0.0)
   rails-controller-testing
   railties (= 5.0.0)

--- a/app/assets/javascripts/screenshots.js
+++ b/app/assets/javascripts/screenshots.js
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+	$('.delete_screenshot').bind('ajax:success', function() {
+		 $(this).closest('tr').fadeOut();
+	});
+});

--- a/app/controllers/screenshots_controller.rb
+++ b/app/controllers/screenshots_controller.rb
@@ -1,0 +1,38 @@
+class ScreenshotsController < ApplicationController
+
+	def index
+		@screenshots = Screenshot.order('created_at DESC')
+	end
+
+	def new
+		@screenshot = Screenshot.new
+	end
+
+	def create
+		@screenshot = Screenshot.new(screenshot_params)
+		if @screenshot.save
+			flash[:success] = "The screenshot was added!"
+			redirect_to screenshots_path
+		else
+			render 'new'
+		end
+	end
+
+	def destroy
+		@screenshot = Screenshot.find(params[:id])
+		@screenshot.destroy
+
+		respond_to do |format|
+			format.html { redirect_to :action => 'index' }
+			format.js   { render :nothing => true }
+			format.json { head :ok }
+		end
+	end
+
+	private
+
+	def screenshot_params
+		params.require(:screenshot).permit(:image, :title)
+	end
+
+end

--- a/app/models/screenshot.rb
+++ b/app/models/screenshot.rb
@@ -1,0 +1,24 @@
+class Screenshot < ApplicationRecord
+  has_attached_file :image,
+    styles: { thumb: ["64x64#", :jpg], :large => "750x" },
+    :url => "/system/:class/:folder1/:folder2/:style/:file_name.:extension"
+
+  validates_attachment :image, presence: true,
+    content_type: { content_type: ["image/jpeg", "image/gif", "image/png"] },
+    size: { in: 0..3.megabytes }
+
+  private
+
+  Paperclip.interpolates :folder1 do |attachment, style|
+    return attachment.hash_key[0,2]
+  end
+
+  Paperclip.interpolates :folder2 do |attachment, style|
+    return attachment.hash_key[2,4]
+  end
+
+  Paperclip.interpolates :file_name do |attachment, style|
+    return attachment.hash_key[5,35]
+  end
+
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
 				<div class="dropdown-menu" aria-labelledby="teamsDropdownMenuLink">
 					<%= link_to 'Manage', teams_path, { :class=>"dropdown-item" } %>
 					<%= link_to 'Team Updates', team_updates_path, { :class=>"dropdown-item" } %>
+					<%= link_to 'Screenshots', screenshots_path, { :class=>"dropdown-item" } %>
 				</div>
 			</li>
 

--- a/app/views/screenshots/_screenshot.html.erb
+++ b/app/views/screenshots/_screenshot.html.erb
@@ -1,0 +1,11 @@
+
+<tr>
+	<td><%= link_to image_tag(screenshot.image.url(:thumb), class: 'media-object'), screenshot.image.url, target: '_blank' %></td>
+	<td><%= screenshot.title %></td>
+	<td>
+		<a href="#" onclick="prompt('Press Ctrl + C, then Enter to copy to clipboard','<%= asset_url(screenshot.image.url(:large)) %>')">Click to Copy</a>
+	</td>
+	<td>
+		<%= link_to 'Delete', screenshot_path(screenshot), data: {confirm: 'Are you sure?'}, method: :delete, remote: true, class: 'delete_screenshot' %>
+	</td>
+</tr>

--- a/app/views/screenshots/index.html.erb
+++ b/app/views/screenshots/index.html.erb
@@ -1,0 +1,15 @@
+<div class="page-header"><h1>Screenshots</h1></div>
+
+<%= link_to 'Add Screenshot', new_screenshot_path %>
+
+<table class="table table-striped table-condensed">
+	<tr>
+		<th class="col-md-1">thumbnail</th>
+		<th class="col-md-2">title</th>
+    <th class="col-md-2">full_path</th>
+		<th class="col-md-9"></th>
+	</tr>
+
+	<%= render @screenshots %>
+
+</table>

--- a/app/views/screenshots/new.html.erb
+++ b/app/views/screenshots/new.html.erb
@@ -1,0 +1,17 @@
+<div class="page-header"><h1>Upload Photo</h1></div>
+
+<%= form_for @screenshot, :html => { :multipart => true } do |f| %>
+  <%= render 'shared/errors', object: @screenshot %>
+
+  <div class="form-group">
+    <%= f.label :title %>
+    <%= f.text_field :title, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :image %>
+    <%= f.file_field :image, class: 'form-control'%>
+  </div>
+
+  <%= f.submit 'Upload', class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,0 +1,13 @@
+<% if object.errors.any? %>
+  <div class="panel panel-warning errors">
+    <div class="panel-heading">
+      <h5><i class="glyphicon glyphicon-exclamation-sign"></i> Found errors while saving</h5>
+    </div>
+
+    <ul class="panel-body">
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/initializers/paperclip_defaults.rb
+++ b/config/initializers/paperclip_defaults.rb
@@ -1,0 +1,6 @@
+
+
+Paperclip::Attachment.default_options.update({
+  url: "/system/:class/:attachment/:id_partition/:style/:hash.:extension",
+  hash_secret: "PabhbX9govqnsiZL+l9pX9jgRgsI+rZPxcxTVETw3I+upssBaebZOltN/3cRjPVe"
+})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Pop::Application.routes.draw do
       end
   end
 
+  resources :screenshots, only: [:new, :create, :index, :destroy]
+
   get 'analytics/objectives'
   get 'analytics/products'
   get 'analytics/products_by_week'

--- a/db/migrate/20170930204053_create_screenshots.rb
+++ b/db/migrate/20170930204053_create_screenshots.rb
@@ -1,0 +1,10 @@
+class CreateScreenshots < ActiveRecord::Migration[5.0]
+  def change
+    create_table :screenshots do |t|
+      t.string :title
+      t.string :caption
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170930204145_add_attachment_image_to_screenshots.rb
+++ b/db/migrate/20170930204145_add_attachment_image_to_screenshots.rb
@@ -1,0 +1,11 @@
+class AddAttachmentImageToScreenshots < ActiveRecord::Migration
+  def self.up
+    change_table :screenshots do |t|
+      t.attachment :image
+    end
+  end
+
+  def self.down
+    remove_attachment :screenshots, :image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170408230900) do
+ActiveRecord::Schema.define(version: 20170930204145) do
 
   create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "title"
@@ -31,6 +31,17 @@ ActiveRecord::Schema.define(version: 20170408230900) do
     t.text     "summary",    limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "screenshots", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "title"
+    t.string   "caption"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
+    t.datetime "image_updated_at"
   end
 
   create_table "team_updates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
Provide the ability to add, remove and manage screenshots (images) directly to pop so that they may be easily included in team updates.